### PR TITLE
Fix bug counting rebuffer time per segment

### DIFF
--- a/dash.js/samples/low-latency-custom/index.html
+++ b/dash.js/samples/low-latency-custom/index.html
@@ -475,7 +475,7 @@
                 // constantly update overall metrics value with the latest cumulative metrics
                 window.abrHistory.overall = history;
                 qoeEvaluator.logSegmentMetrics(currentMetrics.segmentBitrateKbps, 
-                                                currentMetrics.stallDurationMs/1000, 
+                                                currentMetrics.segmentStallDurationMs/1000, 
                                                 currentLatency, currentMetrics.playbackSpeed);
             });
 


### PR DESCRIPTION
### What does this PR do?
- Uses `segmentStallDurationMs` for the per-segment QoE score instead of `stallDurationMs`